### PR TITLE
fix test mistake

### DIFF
--- a/verification/tests.py
+++ b/verification/tests.py
@@ -46,7 +46,7 @@ TESTS = {
 
         {
             "input": ['(CH3COO)2Ca', 4],
-            "answer": ['H', 'O'],
+            "answer": ['C', 'H', 'O'],
         }
 
     ]


### PR DESCRIPTION
atoms("(CH3COO)2Ca", 4) must return ["C","H","O"], not ["H","O"]